### PR TITLE
add LUME, three-elements, and fast

### DIFF
--- a/registry.v1.json
+++ b/registry.v1.json
@@ -13,6 +13,13 @@
             "affected": "ce",
         }
     ],
+    "fast": [
+        {
+            "name": "fast",
+            "url": "https://github.com/microsoft/fast",
+            "affected": "ce",
+        }
+    ],
     "a11y": [
         {
             "name":"lrnwebcomponents",

--- a/registry.v1.json
+++ b/registry.v1.json
@@ -1,4 +1,11 @@
 {
+    "lume": [
+        {
+            "name": "LUME",
+            "url": "https://github.com/lume/lume",
+            "affected": "ce",
+        }
+    ],
     "a11y": [
         {
             "name":"lrnwebcomponents",

--- a/registry.v1.json
+++ b/registry.v1.json
@@ -6,6 +6,13 @@
             "affected": "ce",
         }
     ],
+    "three": [
+        {
+            "name": "three-elements",
+            "url": "https://github.com/hmans/three-elements",
+            "affected": "ce",
+        }
+    ],
     "a11y": [
         {
             "name":"lrnwebcomponents",


### PR DESCRIPTION
I think I did that right.

 LUME uses `lume-` for all elements by default (but it can be configured by the user if they wish).

Additionally it also creates a `has=""` attribute (see http://github.com/lume/element-behaviors) usable on any element. I guess it is either namespace-less, or the namespace is `has`.