### PR TITLE
Add carbon-web-components

### DIFF
--- a/registry.v1.json
+++ b/registry.v1.json
@@ -250,5 +250,19 @@
             "url": "https://github.com/ing-bank/lion",
             "affected": ["ce"]
         }
+    ],
+    "bx": [
+        {
+            "name": "Carbon Web Components",
+            "url": "https://github.com/carbon-design-system/carbon-web-components",
+            "affected": ["ce"]
+        }
+    ],
+    "dds": [
+        {
+            "name": "Carbon for IBM.com Web Components",
+            "url": "https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/master/packages/web-components",
+            "affected": ["ce"]
+        }
     ]
 }


### PR DESCRIPTION
Also adds [`@carbon/ibmdotcom-web-components`](https://www.npmjs.com/package/@carbon/ibmdotcom-web-components), a [`carbon-web-components`](https://www.npmjs.com/package/carbon-web-components) variant for IBM.com websites.

Refs carbon-design-system/carbon-web-components#606.